### PR TITLE
Remove yo as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,5 @@
     "grunt": "=0.4.5",
     "grunt-sg-release": "=0.2.2",
     "mocha": "*"
-  },
-  "peerDependencies": {
-    "yo": ">=1.0.0"
   }
 }


### PR DESCRIPTION
Peer dependencies are gone with npm 3.

See https://twitter.com/Vaxilart/status/666698958975148033

This might confuse people using npm 3:
![screenshot](http://f.cl.ly/items/1t1e1x2x47383u0Q0j3G/Bildschirmfoto%202016-01-09%20um%2019.03.08.png)